### PR TITLE
[Fixed] AttributeError: module 'tensorflow.contrib' has no attribute 'lite'

### DIFF
--- a/runtime-modeling/main_tflite.py
+++ b/runtime-modeling/main_tflite.py
@@ -560,7 +560,7 @@ def export(est, export_dir, post_quantize=True):
       serving_input_receiver_fn=image_serving_input_fn)
 
   tf.logging.info('Starting to export TFLite.')
-  converter = tf.contrib.lite.TFLiteConverter.from_saved_model(
+  converter = tf.lite.TFLiteConverter.from_saved_model(
       os.path.join(export_dir, subfolder),
       input_arrays=['truediv'],
       output_arrays=['logits'])


### PR DESCRIPTION
I encountered 
```AttributeError: module 'tensorflow.contrib' has no attribute 'lite'```

According to the https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/lite/TFLiteConverter, we do not need .contrib to call .lite